### PR TITLE
fix: 弹出调试弹窗后，点击气泡也会关闭弹窗

### DIFF
--- a/src/devTools/index.js
+++ b/src/devTools/index.js
@@ -128,6 +128,7 @@ const devTools = {
 
     //! 已经打开了调试工具，不要重复显示
     if (pages[pages.length - 1].route == this.options.devRoute) {
+      this.hide()
       return false;
     }
 


### PR DESCRIPTION
调试弹窗出来后，气泡会存在，在app端想关闭弹窗，还得去点 叉号 关闭，有点难受，我觉得还是仿照 eruda 点击气泡就关闭。然后有可能再仿照做一下透明处理。希望能采纳。谢谢。