### PR TITLE
清空全部 log 提示时间及 bug 修改

### DIFF
--- a/src/devTools/core/libs/devCache.js
+++ b/src/devTools/core/libs/devCache.js
@@ -46,6 +46,13 @@ export default {
       }
       // #endif
 
+      // #ifdef APP-PLUS
+      // 直接走设置缓存
+      if (1) {
+        return uni.setStorageSync(key, value);
+      }
+      // #endif
+
       this.tempData[key] = value;
     } catch (error) {
       console.log("devCache.set error", error);
@@ -70,6 +77,13 @@ export default {
       let pages = getCurrentPages()
       if (pages[pages.length - 1].route == "devTools/page/index") {
         // devtools 页面直接走设置缓存
+        return uni.getStorageSync(key);
+      }
+      // #endif
+
+      // #ifdef APP-PLUS
+      // 直接走设置缓存
+      if (1) {
         return uni.getStorageSync(key);
       }
       // #endif

--- a/src/devTools/page/components/bottomTools.vue
+++ b/src/devTools/page/components/bottomTools.vue
@@ -556,6 +556,7 @@ export default {
               title: "处理中...",
             });
 
+            let ms = 500;
             if (type == "error") {
               devCache.set("errorReport", []);
             } else if (type == "console") {
@@ -572,18 +573,19 @@ export default {
               devCache.set("dayOnline", []);
             } else if (type == "storage") {
               that.delStorage();
+              ms += 4000;
             }
 
             setTimeout(() => {
               that.$emit("getPage");
-            }, 5500);
+            }, ms + 500);
             setTimeout(() => {
               uni.hideLoading();
               uni.showToast({
                 title: "清空成功！",
                 icon: "success",
               });
-            }, 5000);
+            }, ms);
           }
         },
       });


### PR DESCRIPTION
一、清空日志提示成功时间是 5 秒，感觉时间太长了，改成 0.5 秒了。
二、首次启动时，清空日志，好像  console 页面并不会刷新，需要手动刷新，猜测是用变量存储须用 nextTick 取值才行，app-pus 也直接用 uni.getStorageSync 了
![Uploading 改之前.gif…]()
